### PR TITLE
Enhancement: #116 #117

### DIFF
--- a/api/annotated/post.py
+++ b/api/annotated/post.py
@@ -6,6 +6,7 @@ from db.sql import dal
 from flask import request
 import tempfile
 import tarfile
+import shutil
 from flask import send_from_directory
 from annotation.main import T2WMLAnnotation
 from db.sql.kgtk import import_kgtk_dataframe
@@ -107,8 +108,11 @@ class AnnotatedData(object):
 
             with tarfile.open(f'{temp_tar_dir}/t2wml_annotation_files.tar.gz', "w:gz") as tar:
                 tar.add(temp_tar_dir, arcname='.')
-            return send_from_directory(temp_tar_dir, 't2wml_annotation_files.tar.gz')
 
+            try:
+                return send_from_directory(temp_tar_dir, 't2wml_annotation_files.tar.gz')
+            finally:
+                shutil.rmtree(temp_tar_dir)
         else:
 
             variable_ids, kgtk_exploded_df = self.generate_kgtk_dataset(dataset, dataset_qnode, df, rename_columns, t2wml_yaml, is_request_put)

--- a/api/annotated/post.py
+++ b/api/annotated/post.py
@@ -1,6 +1,7 @@
 import json
 import sys
 import pandas as pd
+from pandas import DataFrame
 from db.sql import dal
 from flask import request
 import tempfile
@@ -118,19 +119,23 @@ class AnnotatedData(object):
                     print(self.vmr.delete(dataset, v))
 
             # import to database
-            s = time()
-            print('number of rows to be imported: {}'.format(len(kgtk_exploded_df)))
-            try:
-                import_kgtk_dataframe(kgtk_exploded_df, is_file_exploded=True)
-            except Exception as e:
-                # Not sure what's going on here, so print for debugging purposes
-                print("Can't import exploded kgtk file")
-                traceback.print_exc(file=sys.stdout)
-                raise e
-            print(f'time take to import kgtk file into database: {time() - s} seconds')
+            self.import_to_database(kgtk_exploded_df)
 
             variables_metadata = []
             for v in variable_ids:
                 variables_metadata.append(self.vmr.get(dataset, variable=v)[0])
             print(f'total time taken: {time() - l}')
             return variables_metadata, 201
+
+    def import_to_database(self, kgtk_exploded_df: DataFrame):
+
+        s = time()
+        print('number of rows to be imported: {}'.format(len(kgtk_exploded_df)))
+        try:
+            import_kgtk_dataframe(kgtk_exploded_df, is_file_exploded=True)
+        except Exception as e:
+            # Not sure what's going on here, so print for debugging purposes
+            print("Can't import exploded kgtk file")
+            traceback.print_exc(file=sys.stdout)
+            raise e
+        print(f'time take to import kgtk file into database: {time() - s} seconds')

--- a/api/annotated/post.py
+++ b/api/annotated/post.py
@@ -29,6 +29,7 @@ class AnnotatedData(object):
         validate = request.args.get('validate', 'true').lower() == 'true'
         files_only = request.args.get('files_only', 'false').lower() == 'true'
         create_if_not_exist = request.args.get('create_if_not_exist', 'false').lower() == 'true'
+        return_tsv = request.args.get('tsv', 'false').lower() == 'true'
 
         # check if the dataset exists
         s = time()
@@ -40,6 +41,10 @@ class AnnotatedData(object):
             return {'Error': 'Dataset not found: {}'.format(dataset)}, 404
 
         file_name = request.files['file'].filename
+        t2wml_yaml = None
+        if 't2wml_yaml' in request.files:
+            request.files['t2wml_yaml'].seek(0)
+            t2wml_yaml = str(request.files['t2wml_yaml'].read(), 'utf-8')
 
         if not (file_name.endswith('.xlsx') or file_name.endswith('.csv')):
             return {"Error": "Please upload an annotated excel file or a csv file "
@@ -102,7 +107,7 @@ class AnnotatedData(object):
 
         else:
             s = time()
-            variable_ids, kgtk_exploded_df = self.ta.process(dataset_qnode, df, rename_columns)
+            variable_ids, kgtk_exploded_df = self.ta.process(dataset_qnode, df, rename_columns, t2wml_yaml=t2wml_yaml)
             print(f'time take to create kgtk files: {time() - s} seconds')
             variable_ids = [v.replace('"', '') for v in variable_ids]
             if is_request_put:

--- a/api/annotated/post.py
+++ b/api/annotated/post.py
@@ -94,7 +94,8 @@ class AnnotatedData(object):
         if files_only:
             t2wml_yaml, combined_item_def_df, consolidated_wikifier_df = self.ta.process(dataset_qnode, df,
                                                                                          rename_columns,
-                                                                                         extra_files=True)
+                                                                                         extra_files=True,
+                                                                                         t2wml_yaml=t2wml_yaml)
 
             temp_tar_dir = tempfile.mkdtemp()
             open(f'{temp_tar_dir}/t2wml.yaml', 'w').write(t2wml_yaml)

--- a/api/tsv/post.py
+++ b/api/tsv/post.py
@@ -30,10 +30,6 @@ class TsvData(object):
         dataset_qnode = dal.get_dataset_id(dataset)
         print(f'time take to get dataset: {time() - s} seconds')
 
-        if not create_if_not_exist and not dataset_qnode:
-            print(f'Dataset not defined: {dataset}')
-            return {'Error': 'Dataset not found: {}'.format(dataset)}, 404
-
         file_name = request.files['file'].filename
 
         if not file_name.endswith('.tsv'):

--- a/api/tsv/post.py
+++ b/api/tsv/post.py
@@ -24,9 +24,6 @@ class TsvData(object):
 
     def process(self, dataset, is_request_put=False):
         l = time()
-        validate = request.args.get('validate', 'true').lower() == 'true'
-        files_only = request.args.get('files_only', 'false').lower() == 'true'
-        create_if_not_exist = request.args.get('create_if_not_exist', 'false').lower() == 'true'
 
         # check if the dataset exists
         s = time()

--- a/data-refresh/DataLoader.ipynb
+++ b/data-refresh/DataLoader.ipynb
@@ -4,7 +4,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# This is a demo on how to upload \\*.csv and \\*.xlsx to Datamart"
+    "# This is a demo on how to use the DataLoader to upload kgtk(\\*.tsv) and annotated spreadsheets (\\*.csv or \\*.xlsx) to Datamart"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Current Support\n",
+    "---\n",
+    "`DataLoader` currently supports the following functionalities:\n",
+    "1. `template` ++ `[spreadsheet]+` => `annotated_spreadsheet` => `Datamart` => `None`\n",
+    "2. `annotated_spreadsheet` ++ `[yaml_file]?` => `Datamart` => **UNION**[`t2wml_output`, `exploded_kgtk`, `None`]\n",
+    "3. `exploded_kgtk` => `Datamart` => `None`"
    ]
   },
   {
@@ -28,26 +40,42 @@
    "source": [
     "# Parameters to be injected\n",
     "\n",
-    "# Required Parameters\n",
-    "datamart_api_url = None\n",
-    "template_path = None\n",
-    "\n",
-    "dataset_path = None\n",
-    "annotated_path = None\n",
-    "\n",
-    "# Optional Parameters\n",
+    "datamart_api_url = 'http://localhost:12543'\n",
+    "# [optional]\n",
     "dataset_id = None\n",
-    "save_template_path = None\n",
-    "dataset_id_to_erase = None\n",
+    "put_data = False\n",
+    "DEBUG = False\n",
+    "\n",
+    "\n",
+    "# [params] combining template and data\n",
+    "template_path = None\n",
+    "dataset_path = None\n",
+    "# [optional params]\n",
     "flag_combine_files = False\n",
-    "DEBUG = False"
+    "save_template_path = None\n",
+    "save_tsv_path = None\n",
+    "save_t2wml_path = None\n",
+    "Verbose = False\n",
+    "\n",
+    "\n",
+    "# [params] submitting one annotated spreadsheet\n",
+    "annotated_path = None\n",
+    "# [optional params]\n",
+    "yamlfile_path = None    \n",
+    "\n",
+    "# [params] submitting kgtk file\n",
+    "tsv_path = None\n",
+    "\n",
+    "\n",
+    "# [params] erase one dataset\n",
+    "dataset_id_to_erase = None"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Import python modules and utilities"
+    "### Import python modules and utilities"
    ]
   },
   {
@@ -81,7 +109,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Build the annotated sheet, and POST it to Datamart"
+    "### Build the annotated sheet, and add it to Datamart"
    ]
   },
   {
@@ -95,28 +123,8 @@
     "    if dataset_id is None:\n",
     "        dataset_id = utility.read_tsv(template_path).iat[0,1]\n",
     "\n",
-    "    nfiles, nsheets = upload.submit_sheet_bulk(datamart_api_url, template_path, dataset_path, flag_combine_files)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "if annotated_path:\n",
-    "    if upload.submit_annotated_sheet(datamart_api_url, annotated_path, put_data=False):\n",
-    "        nsheets += 1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(f'{nfiles} files processed.')\n",
-    "print(f'{nsheets} sheets uploaded.')"
+    "    nfiles, nsheets = upload.submit_sheet_bulk(datamart_api_url, template_path, \n",
+    "                                               dataset_path, flag_combine_files, put_data)"
    ]
   },
   {
@@ -134,6 +142,63 @@
    "source": [
     "if not save_template_path is None:\n",
     "    template.save_annotation_template(utility.read_tsv(template_path), save_template_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get the annotated sheet, and add it to Datamart\n",
+    "\n",
+    "Returned files will be saved at save_tsv or save_files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if annotated_path:\n",
+    "    if upload.submit_annotated_sheet(datamart_api_url, annotated_path, yamlfile_path, put_data=put_data,\n",
+    "                                        verbose=Verbose, save_tsv=save_tsv_path, save_files=save_t2wml_path):\n",
+    "        nsheets += 1\n",
+    "        nfiles += 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get tsv file, and add it to Datamart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if tsv_path:\n",
+    "    if upload.submit_tsv(datamart_api_url, tsv_path, put_data=put_data):\n",
+    "        nfiles += 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Generate statistics for bug checking"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f'{nfiles} files processed.')\n",
+    "print(f'{nsheets} sheets uploaded.')"
    ]
   },
   {

--- a/data-refresh/utils/__init__.py
+++ b/data-refresh/utils/__init__.py
@@ -1,6 +1,6 @@
 from utils.spreadsheet import *
 from utils.template import *
 from utils.utility import *
-from utils.upload import submit_sheet, submit_sheet_bulk, submit_files
+from utils.upload import submit_sheet, submit_sheet_bulk, submit_files, submit_tsv
 from utils.erase import *
 from utils.test import visualize

--- a/data-refresh/utils/__init__.py
+++ b/data-refresh/utils/__init__.py
@@ -1,6 +1,6 @@
 from utils.spreadsheet import *
 from utils.template import *
 from utils.utility import *
-from utils.upload import submit_sheet, submit_sheet_bulk
+from utils.upload import submit_sheet, submit_sheet_bulk, submit_files
 from utils.erase import *
 from utils.test import visualize

--- a/data-refresh/utils/__init__.py
+++ b/data-refresh/utils/__init__.py
@@ -1,6 +1,6 @@
 from utils.spreadsheet import *
 from utils.template import *
 from utils.utility import *
-from utils.upload import submit_sheet, submit_sheet_bulk, submit_files, submit_tsv
+from utils.upload import submit_sheet_bulk, submit_files, submit_tsv
 from utils.erase import *
 from utils.test import visualize

--- a/data-refresh/utils/upload.py
+++ b/data-refresh/utils/upload.py
@@ -68,13 +68,13 @@ def submit_tsv(datamart_url: str, file_path: str, put_data: Optional[bool] = Tru
     # Send to Datamart
     response = submit_files(url, files, params)
 
-    if response.status_code in [200, 201, 204]:
-        if verbose:
-            print(json.dumps(response.json(), indent=2))
-        return True
+    if not response.status_code in [200, 201, 204]:
+        print(json.dumps(response.json(), indent=2))
+        return False
 
-    print(json.dumps(response.json(), indent=2))
-    return False
+    if verbose:
+        print(json.dumps(response.json(), indent=2))
+    return True
 
 def submit_annotated_sheet(datamart_url: str, annotated_path: str, yaml_path: Optional[str]=None,
                             put_data: Optional[bool]=False, verbose: Optional[bool] = False,

--- a/data-refresh/utils/upload.py
+++ b/data-refresh/utils/upload.py
@@ -154,7 +154,7 @@ def submit_annotated_dataframe(datamart_url: str, annotated_df: DataFrame, yaml_
     return submit_annotated_sheet(datamart_url, input_file.name, yaml_path, put_data, verbose, save_tsv, save_files)
 
 def submit_sheet_bulk(datamart_api_url: str, template_path: str, dataset_path: str,
-                        flag_combine_sheets: bool=False) -> None:
+                        flag_combine_sheets: bool=False, put_data: bool=False) -> None:
     ''' Submit multiple annotated sheets to Datamart
         Args:
             datamart_api_url: Datamart url
@@ -169,6 +169,6 @@ def submit_sheet_bulk(datamart_api_url: str, template_path: str, dataset_path: s
     file_counts = 0
     for annotated_sheet, ct in create_annotated_sheet(template_path, dataset_path, flag_combine_sheets):
         file_counts = ct
-        if submit_annotated_dataframe(datamart_api_url, annotated_sheet):
+        if submit_annotated_dataframe(datamart_api_url, annotated_sheet, put_data=put_data):
             sheets_submitted += 1
     return file_counts, sheets_submitted

--- a/data-refresh/utils/upload.py
+++ b/data-refresh/utils/upload.py
@@ -6,6 +6,16 @@ from requests import post, put
 from requests.models import Response
 from typing import Dict, Optional
 
+'''
+This module contains the following functions:
+    submit_files() -> submit some files to Datamart with given parameters
+    submit_tsv() -> submit exploded kgtk file to Datamart with given parameters
+    submit_annotated_sheet() -> submit annotated spreadsheet (csv or xlsx) file to Datamart,
+                                  can add optional YAML file and save_tsv path,
+                                  can save t2wml output or exploded kgtk files
+
+'''
+
 sheet_id = 0
 
 def submit_files(url:str, files: Dict, params: Dict) -> Response:
@@ -50,10 +60,12 @@ def submit_tsv(datamart_url: str, file_path: str, put_data: Optional[bool] = Tru
     file_name = os.path.basename(file_path)
     dataset_id = find_dataset_id(file_path)
 
+    # Supply arguments
     url = f'{datamart_url}/datasets/{dataset_id}/tsv'
     files = { 'file': (file_name, open(file_path, mode='rb'), 'application/octet-stream') }
     params = { 'put_data': put_data }
 
+    # Send to Datamart
     response = submit_files(url, files, params)
 
     if response.status_code in [200, 201, 204]:
@@ -63,6 +75,69 @@ def submit_tsv(datamart_url: str, file_path: str, put_data: Optional[bool] = Tru
 
     print(json.dumps(response.json(), indent=2))
     return False
+
+def submit_annotated_sheet(datamart_url: str, annotated_path: str, yaml_path: Optional[str]=None,
+                            put_data: Optional[bool]=False, verbose: Optional[bool] = False,
+                            save_tsv: Optional[str]=None, save_files: Optional[str]=None) -> bool:
+    ''' Submit an annotated sheet
+        Args:
+            datamart_url: Datamart base address
+            annotated_path: The annotated file path
+            yaml_path: The optional yaml file for parsing the dataset
+            put_data: Whether to PUT or POST the data to Datamart
+            verbose: Whether to show variable metadata upon submission success
+            save_tsv: If supplied, the path of the tar.gz file it will be saved
+            save_files: If supplied, the path of the tar.gz file to save T2WML configuration files
+        Returns:
+            A boolean values indicates whether the sheet is uploaded successfully
+    '''
+    def find_dataset_id(file_path: str):
+        if file_path.endswith('.xlsx'):
+            df = pd.read_excel(file_path, header=None, dtype=object).fillna('')
+        else:
+            df = pd.read_csv(file_path, header=None, encoding='latin1', dtype=object).fillna('')
+        return df.iat[0,1]
+
+    if not (annotated_path.endswith('.xlsx') or annotated_path.endswith('.csv')):
+        print(f'Error: Unknown file type - {annotated_path}')
+        return False
+
+    file_name = os.path.basename(annotated_path)
+    dataset_id = find_dataset_id(annotated_path)
+
+    # Supply arguments
+    url = f'{datamart_url}/datasets/{dataset_id}/annotated'
+
+    files = { 'file': (file_name, open(annotated_path, mode='rb'), 'application/octet-stream') }
+    if yaml_path:
+        files['t2wml_yaml'] = os.path.basename(yaml_path), open(yaml_path, mode='rb'), 'application/octet-stream'
+
+    params = { 'put_data': put_data, 'create_if_not_exist': True,
+                'tsv': bool(save_tsv), 'files_only': bool(save_files) }
+
+    # Send to Datamart
+    response = submit_files(url, files, params)
+
+    if not response.status_code in [200, 201, 204]:
+        print(json.dumps(response.json(), indent=2))
+        return False
+
+    # Generate output
+    if save_tsv:
+        if not save_tsv.endswith('.tar.gz'):
+            save_tsv += '-d.tar.gz'
+        with open(save_tsv, 'wb') as fd:
+            fd.write(response.content)
+
+    if save_files:
+        if not save_files.endswith('.tar.gz'):
+            save_files += '-d.tar.gz'
+        with open(save_files, 'wb') as fd:
+            fd.write(response.content)
+
+    if verbose:
+        print(json.dumps(response.json(), indent=2))
+    return True
 
 def upload_data_annotated(url: str, file_path: str, yamlfile_path: str=None,
                             fBuffer: io.StringIO=None, put_data: bool=False) -> bool:
@@ -123,31 +198,6 @@ def submit_sheet(datamart_api_url: str, annotated_sheet: DataFrame,
     if tsv:
         url += '&tsv=true'
     return upload_data_annotated(url, '', None, buffer, put_data)
-
-def submit_annotated_sheet(datamart_api_url: str, annotated_sheet: str, yamlfile_path: str=None,
-                            put_data: bool=False, tsv: bool=False) -> bool:
-    ''' Submit an annotated sheet
-        Args:
-            datamart_api_url: Datamart url
-            annotated_sheet: The annotated sheet path
-        Returns:
-            A boolean values indicates whether the sheet is uploaded successfully
-    '''
-
-    if annotated_sheet.endswith('.xlsx'):
-        df = pd.read_excel(annotated_sheet, header=None, dtype=object).fillna('')
-    elif annotated_sheet.endswith('.csv'):
-        df = pd.read_csv(annotated_sheet, header=None, encoding='latin1', dtype=object).fillna('')
-    else:
-        print(f'Unknown file type: {annotated_sheet}')
-        return False
-
-    dataset_id = df.iat[0,1]
-    url = f'{datamart_api_url}/datasets/{dataset_id}/annotated?create_if_not_exist=true'
-    if tsv:
-        url += '&tsv=true'
-
-    return upload_data_annotated(url, annotated_sheet, yamlfile_path, None, put_data)
 
 def submit_sheet_bulk(datamart_api_url: str, template_path: str, dataset_path: str,
                         flag_combine_sheets: bool=False) -> None:


### PR DESCRIPTION
#116 #117 @kyao 
Endpoints linked with Data Refresher's `DataLoader.ipynb`. Currently writing test scripts, will conduct a formal pull request after Monday's meeting.

What have changed to the `datamart-api` and `t2wml-annotation`?

1. Class `T2WMLAnnotation` new accepts optional YAML file to generate kgtk edges.
2. Some changes are made to the class `AnnotatedData`. Several common subroutines have been abstracted as member functions, and process() return different values based on request parameters.
   - `files_only`: Returns tar.gz containing the t2wml-output files
   - `tsv`: Returns tar.gz containing the exploded kgtk file
   - `None`: Returns variable metadata
3. Fix some memory leak issues
4. An enhanced interface for `data-refresh`, users will be able to upload one of the following to Datamart:
   - template + spreadsheets
   - annotated spreadsheets
   - tsv file
   The interface will output t2wml_output or kgtk files per user request.

A unit test module is being written. After I test it against a confident number of datasets, I will make the pull request and integrate the code with `Datamart`. To avoid any potential conflicts, I plan to release the code later today.
