### PR TITLE
fix inconsistencies of returning tsv

### DIFF
--- a/api/annotated/post.py
+++ b/api/annotated/post.py
@@ -130,7 +130,7 @@ class AnnotatedData(object):
 
             # Generate dataset metadata kgtk file and explode it
             metadata_path = f'/{temp_tar_dir}/{dataset}-metadata-exploded.tsv'
-            if not metadata_edges:
+            if metadata_edges is None:
                 metadata_edges = self.generate_kgtk_dataset_metadata(dataset)
             metadata_df = pd.DataFrame(metadata_edges)
             metadata_df.to_csv(metadata_path, index=None, sep='\t', quoting=csv.QUOTE_NONE, quotechar='')


### PR DESCRIPTION
@kyao A minor fix in generating dataset metadata when metadata edges are returned by T2WMLAnnotation.